### PR TITLE
replace load static instead of staticfiles

### DIFF
--- a/rest_framework_swagger/templates/rest_framework_swagger/index.html
+++ b/rest_framework_swagger/templates/rest_framework_swagger/index.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
load 'staticfiles' removed in django >= 3.0 and is not working. so it replaced with load 'static'